### PR TITLE
Fix ssh login failure

### DIFF
--- a/init/mkdumprd
+++ b/init/mkdumprd
@@ -142,9 +142,6 @@ function run_dracut()
     # Make resolved variables visible to the dracut module
     kdump_export_targets
 
-    # Include additional files in the kdump initial ram disk
-    DRACUT_ARGS="$DRACUT_ARGS --install '/etc/hosts /etc/nsswitch.conf'"
-
     DRACUT_ARGS="$DRACUT_ARGS --add 'kdump' $INITRD $KERNELVERSION"
     echo "Regenerating kdump initrd ..." >&2
     eval "bash -$- $DRACUT $DRACUT_ARGS"

--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -866,6 +866,8 @@ function kdump_modify_config()						   # {{{
             KDUMP_SAVEDIR="${KDUMP_SAVEDIR}file://${kdump_Realpath[i]}"
 	elif [ "$protocol" != "srcfile" ] ; then
             KDUMP_SAVEDIR="${KDUMP_SAVEDIR}${kdump_URL[i]}"
+            cp /etc/hosts "${dest}/etc"
+            grep '^hosts:' /etc/nsswitch.conf > "${dest}/etc/nsswitch.conf"
 	fi
 
 	#

--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -875,11 +875,11 @@ function kdump_modify_config()						   # {{{
             kdump_over_ssh=yes
             if [ -z "$KDUMP_HOST_KEY" ] ; then
 		KDUMP_HOST_KEY=$(
-		    ssh-keygen -F "$kdump_Host" 2>/dev/null | \
+		    ssh-keygen -F "${kdump_Host[i]}" 2>/dev/null | \
 		    awk '/^[^#]/ { if (NF==3) { print $3; exit } }'
 		)
             fi
-	    ssh-keygen -F "$kdump_Host" 2> /dev/null \
+	    ssh-keygen -F "${kdump_Host[i]}" 2> /dev/null \
 		>>"${dest}/kdump/.ssh/known_hosts"
 	fi
 


### PR DESCRIPTION
Kdump over ssh failed because missing libnss_files.so required by /etc/nsswitch.conf.
In fact /etc/nsswitch.conf is introduced to support /etc/hosts.  The passwd field is not intended.
So a better fix is leave unnecessary fields out.