### PR TITLE
Enable kdump features in initramfs only when kdump is active (bsc#1101730)

### DIFF
--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -85,6 +85,7 @@ INSTALL(
 INSTALL(
     FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/kdump-root.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/kdump-boot.sh
         ${CMAKE_CURRENT_SOURCE_DIR}/module-setup.sh
         ${CMAKE_CURRENT_SOURCE_DIR}/mount-kdump.sh
     DESTINATION

--- a/init/kdump-boot.sh
+++ b/init/kdump-boot.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# An Initrd with dump capturing support can boot a production kernel
+# as well (FADump). In such scenario, apply optimizations only while
+# booting the capture kernel - this is a kernel that
+#   a) has a /proc/vmcore file waiting to be saved.
+#   b) reboots after saving the dump.
+
+# apply multipath optimizations
+if [ -s /proc/vmcore ]; then
+    # Replace the multipath.conf file with the one optimized for kdump.
+    rm -f /etc/multipath.conf
+    mv /etc/multipath.conf.kdump /etc/multipath.conf
+fi

--- a/init/kdump-boot.sh
+++ b/init/kdump-boot.sh
@@ -3,8 +3,9 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
 # An Initrd with dump capturing support can boot a production kernel
-# as well (FADump). In such scenario, apply optimizations only while
-# booting the capture kernel - this is a kernel that
+# as well (FADump). In such scenario, apply optimizations and enforce
+# bringing up dump target only while booting the capture kernel - this
+# is a kernel that
 #   a) has a /proc/vmcore file waiting to be saved.
 #   b) reboots after saving the dump.
 
@@ -13,4 +14,7 @@ if [ -s /proc/vmcore ]; then
     # Replace the multipath.conf file with the one optimized for kdump.
     rm -f /etc/multipath.conf
     mv /etc/multipath.conf.kdump /etc/multipath.conf
+else
+    # avoid enforing network bring up while booting production kernel.
+    rm -f /etc/cmdline.d/99kdump-net.conf
 fi

--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -231,6 +231,7 @@ install() {
     kdump_setup_files "$initdir" "$kdump_mpath_wwids"
 
     inst_hook cmdline 50 "$moddir/kdump-root.sh"
+    inst_hook cmdline 50 "$moddir/kdump-boot.sh"
     if dracut_module_included "systemd" ; then
 	inst_binary "$moddir/device-timeout-generator" \
 	    "$systemdutildir"/system-generators/kdump-device-timeout-generator

--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -205,10 +205,12 @@ kdump_cmdline_ip() {
     esac
 }
 
-cmdline() {
+cmdline_zfcp() {
     local _arch=$(uname -m)
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] && kdump_cmdline_zfcp
+}
 
+cmdline_net() {
     kdump_cmdline_ip
 }
 
@@ -219,8 +221,11 @@ installkernel() {
 
 install() {
     if [[ $hostonly_cmdline == "yes" ]] ; then
-        local _cmdline=$(cmdline)
-        [ -n "$_cmdline" ] && printf "%s\n" "$_cmdline" >> "${initdir}/etc/cmdline.d/99kdump.conf"
+        local _cmdline=$(cmdline_zfcp)
+        [ -n "$_cmdline" ] && printf "%s\n" "$_cmdline" >> "${initdir}/etc/cmdline.d/99kdump-zfcp.conf"
+
+        _cmdline=$(cmdline_net)
+        [ -n "$_cmdline" ] && printf "%s\n" "$_cmdline" >> "${initdir}/etc/cmdline.d/99kdump-net.conf"
     fi
 
     # Get a list of required multipath devices

--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -1180,7 +1180,7 @@ function kdump_setup_files()						   # {{{
     #
     # create modified multipath.conf
     #
-    kdump_modify_multipath "$mpathdevs" > "${outdir}/etc/multipath.conf"
+    kdump_modify_multipath "$mpathdevs" > "${outdir}/etc/multipath.conf.kdump"
 
     #
     # filter out problematic sysctl settings


### PR DESCRIPTION
The kdump module can be included in the normal (non-kdump) initramfs. It is needed for fadump to work because it uses the normal initramfs to capture the kernel core. In that case some features might interfere with normal boot when kdump is not active. In particular network interfaces only needed for capturing the kernel core need not be initialized in initramfs for normal boot. Also multipath.conf cannot blacklist devices not needed for saving kernel dump during normal boot.