### PR TITLE
Add fence_kdump_send automatically when fence-agents installed.

### DIFF
--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -25,9 +25,8 @@ kdump_check_net() {
     elif [ "${KDUMP_NETCONFIG%:force}" != "$KDUMP_NETCONFIG" ]; then
         # always set up network
         kdump_neednet=y
-    elif [ -f "/usr/lib/fence_kdump_send" ] &&
-         ( [[ $KDUMP_PRESCRIPT =~ "fence_kdump_send" ]] || \
-         [[ $KDUMP_POSTSCRIPT =~ "fence_kdump_send" ]] ) ; then
+    elif [ -f "$FENCE_KDUMP_SEND" ] &&
+         [[ $KDUMP_POSTSCRIPT =~ "$FENCE_KDUMP_SEND" ]] ; then
         # setup network when fence_kdump_send included and configured
         kdump_neednet=y
     else

--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -25,6 +25,11 @@ kdump_check_net() {
     elif [ "${KDUMP_NETCONFIG%:force}" != "$KDUMP_NETCONFIG" ]; then
         # always set up network
         kdump_neednet=y
+    elif [ -f "/usr/lib/fence_kdump_send" ] &&
+         ( [[ $KDUMP_PRESCRIPT =~ "fence_kdump_send" ]] || \
+         [[ $KDUMP_POSTSCRIPT =~ "fence_kdump_send" ]] ) ; then
+        # setup network when fence_kdump_send included and configured
+        kdump_neednet=y
     else
         kdump_neednet=
         for protocol in "${kdump_Protocol[@]}" ; do

--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -906,6 +906,13 @@ function kdump_modify_config()						   # {{{
 	KDUMP_REQUIRED_PROGRAMS="$KDUMP_REQUIRED_PROGRAMS ssh"
     fi
 
+    # copy fence_kdump_send if exists
+    if [ -f "/usr/lib/fence_kdump_send" ] &&
+       ( [[ $KDUMP_PRESCRIPT =~ "fence_kdump_send" ]] ||
+       [[ $KDUMP_POSTSCRIPT =~ "fence_kdump_send" ]] ) ; then
+        KDUMP_REQUIRED_PROGRAMS="$KDUMP_REQUIRED_PROGRAMS /usr/lib/fence_kdump_send"
+    fi
+
     #
     # dump the configuration file, modifying:
     #   KDUMP_SAVEDIR  -> resolved path

--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -10,6 +10,7 @@
 #
 
 KDUMP_CONFIG=/etc/sysconfig/kdump
+FENCE_KDUMP_SEND=/usr/lib/fence_kdump_send
 
 # Extract the device name from a route
 #
@@ -907,10 +908,9 @@ function kdump_modify_config()						   # {{{
     fi
 
     # copy fence_kdump_send if exists
-    if [ -f "/usr/lib/fence_kdump_send" ] &&
-       ( [[ $KDUMP_PRESCRIPT =~ "fence_kdump_send" ]] ||
-       [[ $KDUMP_POSTSCRIPT =~ "fence_kdump_send" ]] ) ; then
-        KDUMP_REQUIRED_PROGRAMS="$KDUMP_REQUIRED_PROGRAMS /usr/lib/fence_kdump_send"
+    if [ -f "$FENCE_KDUMP_SEND" ] &&
+       [[ $KDUMP_POSTSCRIPT =~ "$FENCE_KDUMP_SEND" ]] ; then
+        KDUMP_REQUIRED_PROGRAMS="$KDUMP_REQUIRED_PROGRAMS $FENCE_KDUMP_SEND"
     fi
 
     #


### PR DESCRIPTION
### What does this PR do?

Automatically add fence_kdump_send and enable network when the library installed and configured in KDUMP_PRESCRIPT or KDUMP_POSTSCRIPT.

### What issues does this PR fix or reference?

[bsc#1108919](https://bugzilla.suse.com/show_bug.cgi?id=1108919) and [fate#326809](https://fate.suse.com/326809)

### Previous Behavior

Need to explicit configure KDUMP_REQUIRED_PROGRAMS="/usr/lib/fence_kdump_send" and  KDUMP_NETCONFIG="XX:force" to include the library and enable the network.
In SLE11SP4 with mkinitrd, doesn't need this steps.

### New Behavior

Include the library when fence-agents installed, enable the network automatically when configure it in PRE/POSTSCRIPT. Keep the consistent steps with SLE11SP4.