### PR TITLE
Use gwaddr from KDUMP_COMMANDLINE_APPEND

### DIFF
--- a/init/setup-kdump.functions
+++ b/init/setup-kdump.functions
@@ -587,7 +587,25 @@ function kdump_ip_config()						   # {{{
 
     done < <(ip -4 address show dev "$iface")
 
-    gwaddr=$(ip route show 0/0 | sed -n 's/.* via \([^ ]*\).*/\1/p')
+    case "$kdump_net_mode" in
+    static)
+        KCA=$(grep ^KDUMP_COMMANDLINE_APPEND /etc/sysconfig/kdump)
+        KCA_GW=$(echo $KCA | cut -d ":" -f 3)
+        echo $KCA_GW | grep -qE "([0-9]{1,3}[\.]){3}[0-9]{1,3}"
+        if [ $? -eq 0 ]; then
+                gwaddr=$(echo $KCA_GW)
+            else
+                gwaddr=$(ip route show 0/0 | sed -n 's/.* via \([^ ]*\).*/\1/p')
+        fi
+        ;;
+    dhcp|dhcp4|dhcp6|auto6)
+        gwaddr=$(ip route show 0/0 | sed -n 's/.* via \([^ ]*\).*/\1/p')
+        ;;
+    *)
+        derror "Wrong KDUMP_NETCONFIG mode: $kdump_net_mode"
+        ;;
+    esac
+
     hostname=$(hostname)
 
     if [ -n "$ipaddr" ] ; then


### PR DESCRIPTION
In case a static network configuration is used and the gateway set in
KDUMP_COMMANDLINE_APPEND is different than the one currently set in the
system, the rebuild of the initrd will generate a non-working
configuration.

This config option should hold "Additional kernel command line options
for the kdump kernel", according to the Implementation Guide. Other
comments from the source also make clear the intent of the option:

    # For static configuration, you may have to add the
    # configuration to KDUMP_COMMANDLINE_APPEND.

In order to set the correct gateway address it is necessary to read the
config, more specifically the 3rd value in the "ip" tuple and use it to
set the correct gateway in the kdump environment.

In the current upstream version, the gateway set is _always_ the current
gateway set in the system:

    590     gwaddr=$(ip route show 0/0 | sed -n 's/.* via \([^ ]*\).*/\1/p')

In order to fix this, $kdump_net_mode is used in a case statement and if
the mode is static, the $gwaddr variable is set using the data inside
the config option. The case statement is reused from
init/module-setup.sh:203 with some slight changes.

On all others dhcp modes, the old "ip route" command is used to read the
current gateway address running in the system.

The previous version of the patch, which didn't include checking the
content of $KCA_GW, has been tested by me and a customer and it fixes
the problem in this corner case.

In this new version I try to mitigate the problem of null or incorrect
address in $KCA_GW (which will also not break the program for users who
use static config plus the current system's gwaddr).

Please feel free to point out any mistakes so I can amend it.