### PR TITLE
kdump: activate udev rules late during boot (bsc#1154837)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ ADD_CUSTOM_TARGET(
 INSTALL(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/70-kdump.rules
     DESTINATION
-        /etc/udev/rules.d
+        /usr/lib/kdump
 )
 
 #

--- a/init/kdump.service
+++ b/init/kdump.service
@@ -5,6 +5,8 @@ After=local-fs.target network.service YaST2-Second-Stage.service YaST2-Firstboot
 [Service]
 Type=oneshot
 ExecStart=/lib/kdump/load.sh --update
+ExecStartPost=-/usr/bin/cp /usr/lib/kdump/70-kdump.rules /run/udev/rules.d/70-kdump.rules
+ExecStopPost=-/usr/bin/rm -f /run/udev/rules.d/70-kdump.rules
 ExecStop=/lib/kdump/unload.sh
 RemainAfterExit=true
 


### PR DESCRIPTION
The kdump udev rule is very broad in scope and may slow down
booting strongly, especially during the coldplug phase where
"add" events for lots of CPU and memory devices have to be
processed. Therefore, activate this rule (which has the purpose
to support real hotplug rather than coldplug) late in the boot
sequence.