### PR TITLE
Make sure that initrd.target.wants directory exists (bsc#1172670)

### DIFF
--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -281,6 +281,7 @@ install() {
             done
         ) > "$_d"/kdump.conf
 
+	mkdir -p "$initdir/$systemdsystemunitdir"/initrd.target.wants
 	ln_r "$systemdsystemunitdir"/kdump-save.service \
 	    "$systemdsystemunitdir"/initrd.target.wants/kdump-save.service
     else


### PR DESCRIPTION
Creation of symbolic link to kdump-save.service will fail if the directory doesn't exists, and dump will not be captured because kdump-service.service is never started.

The user will see the rescue mode prompt in this case because systemd will proceed to initrd-switch-root, which will fail (triggering rescue mode) because kdump initrd does not setup /sysroot properly.

See: https://bugzilla.opensuse.org/show_bug.cgi?id=1172670