### PR TITLE
remove console=hvc0 from commandline

### DIFF
--- a/init/load.sh
+++ b/init/load.sh
@@ -82,7 +82,7 @@ function build_kdump_commandline()
             test -n "$boot_apicid" && \
 		commandline="$commandline disable_cpu_apicid=$boot_apicid"
             commandline=$(echo "$commandline" |
-                remove_from_commandline 'unknown_nmi_panic|notsc')
+                remove_from_commandline 'unknown_nmi_panic|notsc|console=hvc0')
             ;;
 	s390*)
 	    commandline="$commandline zfcp.allow_lun_scan=0"


### PR DESCRIPTION
If kdump is prepared in a dom0, the dom0 kernel cmdline is used
verbatim for the kdump kernel, modulo known-to-be-bad options.
As a result 'console=hvc0' is passed to the kdump kernel.
In a native environment this option causes the kdump kernel to hang,
the system never comes back.

Remove it from the kdump cmdline to make sure the kdump kernel boots.

Signed-off-by: Olaf Hering <olaf@aepfle.de>