### PR TITLE
Fix kdump initrd path (boo#1190920)

### DIFF
--- a/kdumptool/kernelpath.cc
+++ b/kdumptool/kernelpath.cc
@@ -53,9 +53,8 @@ KernelPath::KernelPath(FilePath const &path)
 {
     Debug::debug()->trace("KernelPath::KernelPath(%s)", path.c_str());
 
-    FilePath canonical = path.getCanonicalPath();
-    m_directory = canonical.dirName();
-    m_name = canonical.baseName();
+    m_directory = path.dirName();
+    m_name = path.baseName();
 
     for (auto const pfx : imageNames(Util::getArch())) {
         if (m_name.startsWith(pfx)) {


### PR DESCRIPTION
Can't use canoncial kernel image path with usrmerge anymore. The kernel
is now in /usr which is to be considered read-only. So the kdump initrd
needs to go to /boot.