### PR TITLE
fadump: isolate fadump initrd image within the default one

### DIFF
--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -117,4 +117,28 @@ INSTALL(
         WORLD_READ
 )
 
+INSTALL(
+    FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/fadump-module-setup.sh
+    RENAME
+        module-setup.sh
+    DESTINATION
+        /usr/lib/dracut/modules.d/99zz-fadumpinit
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
+INSTALL(
+    FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/init-fadump.sh
+    DESTINATION
+        /usr/lib/dracut/modules.d/99zz-fadumpinit
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
 # vim: set sw=4 ts=4 et:

--- a/init/fadump-module-setup.sh
+++ b/init/fadump-module-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+check() {
+    return 255
+}
+
+depends() {
+    return 0
+}
+
+install() {
+    mv -f "$initdir/init" "$initdir/init.dracut"
+    inst_script "$moddir/init-fadump.sh" /init
+    chmod a+x "$initdir/init"
+
+    # Install required binaries for the init script (init-fadump.sh)
+    inst_multiple sh modprobe grep mkdir mount ls mv switch_root
+}

--- a/init/init-fadump.sh
+++ b/init/init-fadump.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+export PATH=/usr/bin:/usr/sbin
+export SYSTEMD_IN_INITRD=lenient
+
+[ -e /proc/mounts ] ||
+	(mkdir -p /proc && mount -t proc -o nosuid,noexec,nodev proc /proc)
+
+grep -q '^sysfs /sys sysfs' /proc/mounts ||
+	(mkdir -p /sys && mount -t sysfs -o nosuid,noexec,nodev sysfs /sys)
+
+if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,opal/dump/mpipl-boot ]; then
+	mkdir /newroot
+	mount -t ramfs ramfs /newroot
+
+	for FILE in $(ls -A /fadumproot/); do
+		mv /fadumproot/$FILE /newroot/
+	done
+	exec switch_root /newroot /init
+else
+	exec /init.dracut
+fi

--- a/init/mkdumprd
+++ b/init/mkdumprd
@@ -91,7 +91,7 @@ function build_fadumprd()
 
     DRACUT_ARGS="--force --add zz-fadumpinit --omit kdump"
 
-    REBUILD_PARAMS="$(lsinitrd $TARGET_INITRD /lib/dracut/build-parameter.txt)"
+    REBUILD_PARAMS="$(cat $BACKUP_INITRD_PARAMS)"
     if ! grep -q "fadumproot" <<< "$REBUILD_PARAMS" ; then
         DRACUT_ARGS="$REBUILD_PARAMS $DRACUT_ARGS"
     fi
@@ -100,10 +100,38 @@ function build_fadumprd()
 }                                                                          # }}}
 
 #
+# Return 0 if $INITRD is already dump capture capable                        {{{
+function is_initrd_dump_capturable()
+{
+    if [ -n "$(lsinitrd $INITRD /lib/dracut/modules.txt | grep ^zz-fadumpinit)" ]; then
+        return 0
+    fi
+
+    return 1
+}                                                                          # }}}
+
+#
+# Backup $INITRD params to $BACKUP_INITRD_PARAMS file                        {{{
+function backup_default_initrd_params()
+{
+    DEFAULT_INITRD=$(basename $INITRD)
+    INITRD_DIR=$(dirname $INITRD)
+    BACKUP_INITRD_PARAMS="$INITRD_DIR/.$DEFAULT_INITRD.params"
+
+    if [ -f $BACKUP_INITRD_PARAMS ] && is_initrd_dump_capturable; then
+        return
+    fi
+
+    echo "Backing up '$INITRD' build parameters before rebuilding it with dump capture support."
+    lsinitrd $INITRD /lib/dracut/build-parameter.txt > $BACKUP_INITRD_PARAMS
+}                                                                          # }}}
+
+#
 # Build $INITRD with dump capture support using dracut                       {{{
 function build_initrd()
 {
     if [ "$KDUMP_FADUMP" = "yes" ] ; then
+        backup_default_initrd_params
         build_fadumprd
     else
         run_dracut

--- a/init/mkdumprd
+++ b/init/mkdumprd
@@ -30,7 +30,7 @@ function usage()
 {
     echo "mkdumprd - Create an initrd for kdump"
     echo ""
-    echo "This script uses mkinitrd(8) internally. Options:"
+    echo "This script uses dracut(8) internally. Options:"
     echo ""
     echo "   -k <version>     Kernel to create the initrd for."
     echo "                    Defaults to the running kernel."
@@ -52,25 +52,6 @@ function status_message()
 }                                                                          # }}}
 
 #
-# Create a new fadump initrd using mkinitrd                                  {{{
-function run_mkinitrd_fadump()
-{
-    # With fadump, we have no control over which kernel will be booted
-    # to save the dump, so do not add any versions here.
-    MKINITRD_ARGS=""
-
-    #
-    # if -q is specified, don't print mkinitrd output
-    if (( $QUIET )) ; then
-	MKINITRD_ARGS="$MKINITRD_ARGS &>/dev/null"
-    fi
-
-    status_message "Calling mkinitrd $MKINITRD_ARGS"
-    echo "Regenerating initrd ..." >&2
-    eval "bash -$- /sbin/mkinitrd $MKINITRD_ARGS"
-}                                                                          # }}}
-
-#
 # Create a new initrd using dracut                                           {{{
 function run_dracut()
 {
@@ -85,6 +66,48 @@ function run_dracut()
     DRACUT_ARGS="$DRACUT_ARGS --add 'kdump' $INITRD $KERNELVERSION"
     echo "Regenerating kdump initrd ..." >&2
     eval "bash -$- $DRACUT $DRACUT_ARGS"
+}                                                                          # }}}
+
+#
+# Build $INITRD for fadump with dump capture support using dracut            {{{
+function build_fadumprd()
+{
+    readonly FADUMP_TMPDIR="$(mktemp -d -t fadump.XXXXXX)"
+    readonly FADUMPRD_TMPDIR="$FADUMP_TMPDIR/fadumproot"
+    readonly TARGET_INITRD="$INITRD"
+
+    INITRD="$FADUMP_TMPDIR/fadump.img"
+    run_dracut
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+
+    mkdir $FADUMPRD_TMPDIR
+    if ! (pushd "$FADUMPRD_TMPDIR" > /dev/null && lsinitrd --unpack $INITRD && popd > /dev/null); then
+        echo "Failed to unpack dump capture scripts."
+        exit 1
+    fi
+
+    DRACUT_ARGS="--force --add zz-fadumpinit --omit kdump"
+
+    REBUILD_PARAMS="$(lsinitrd $TARGET_INITRD /lib/dracut/build-parameter.txt)"
+    if ! grep -q "fadumproot" <<< "$REBUILD_PARAMS" ; then
+        DRACUT_ARGS="$REBUILD_PARAMS $DRACUT_ARGS"
+    fi
+
+    eval "bash -$- $DRACUT $DRACUT_ARGS -i $FADUMPRD_TMPDIR /fadumproot $TARGET_INITRD"
+}                                                                          # }}}
+
+#
+# Build $INITRD with dump capture support using dracut                       {{{
+function build_initrd()
+{
+    if [ "$KDUMP_FADUMP" = "yes" ] ; then
+        build_fadumprd
+    else
+        run_dracut
+    fi
 }                                                                          # }}}
 
 
@@ -165,12 +188,8 @@ if (( ! $FORCE )) ; then
     fi
 fi
 
-if [ "$KDUMP_FADUMP" = "yes" ] ; then
-    run_mkinitrd_fadump
-else
-    run_dracut
-fi
+build_initrd
 
-exit $ret
+exit $?
 
 # vim: set ts=4 sw=4 et fdm=marker: :collapseFolds=1:


### PR DESCRIPTION
In case of fadump, the initrd image has to be built to boot into the
production environment as well as to offload the active crash dump to
the specified dump target (for boot after crash). As the same image
would be used for both boot scenarios, it could not be built optimally
while accommodating both cases.

Swtich to dracut instead of mkinitrd to build the initrd image. And
use '--include' dracut option to include the initrd image, built for
offloading active crash dump, into the default initrd. Also, introduce
a new out-of-tree dracut module (99zz-fadumpinit) that installs a
customized init program while moving default /init to /init.dracut.
This customized init program is leveraged to isolate fadump image
within the default initrd image by kicking off default boot process
(exec /init.dracut) for regular boot scenario and activating fadump
initrd image, if the system is booting after crash.

Before updating initrd to handle both production kernel boot and
capture kernel boot scenario, backup default initrd build parameters.
This helps in rebuilding initrd based on parameters used to build
the default initrd.