### PR TITLE
add watchdog modules in initrd

### DIFF
--- a/init/module-setup.sh
+++ b/init/module-setup.sh
@@ -132,6 +132,8 @@ depends() {
     _modules[drm]=
 
     [ "$kdump_neednet" = y ] && _modules[network]=
+    
+    _modules[watchdog-modules]=
 
     for protocol in "${kdump_Protocol[@]}" ; do
 	if [ "$protocol" = "nfs" ]; then


### PR DESCRIPTION
Modules for watchdogs present on the system should be included in the initrd, otherwise the dump may be interrupted by a watchdog.
Add a dependency on the watchdog-modules dracut module.