### PR TITLE
unload.sh: support kexec unload when kexec_file_load is required

### DIFF
--- a/init/unload.sh
+++ b/init/unload.sh
@@ -17,7 +17,7 @@ if [ "$KDUMP_FADUMP" = "yes" ]; then
 	echo 0 > "$FADUMP_REGISTERED"
     fi
 else
-    $KEXEC -p -u
+    $KEXEC -a -p -u
 fi
 
 test $? -eq 0 || exit 1


### PR DESCRIPTION
Some systems, such as those using secure boot, require the use of
the kexec_file_load syscall instead of kexec_load.

Using kexe -a -p -u will try the new kexec_file_load syscall first,
and if it is not supported, fall back to using the old kexec_load.