### PR TITLE
Fix network-related dracut options handling for fadump case

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -178,7 +178,15 @@ kdump_cmdline_zfcp() {
 
 kdump_ip_set_explicitly() {
     local _opt
-    for _opt in $KDUMP_COMMANDLINE $KDUMP_COMMANDLINE_APPEND
+    local opts
+
+    if [ "$KDUMP_FADUMP" = yes ]; then
+        _opts="`cat /proc/cmdline`"
+    else
+        _opts="$KDUMP_COMMANDLINE $KDUMP_COMMANDLINE_APPEND"
+    fi
+
+    for _opt in $_opts
     do
         if [ "${_opt%%=*}" = "ip" -a \
              "${_opt#*=}" != "$_opt" ]


### PR DESCRIPTION
Commit bbe9b1281cd6 ("Do not add  network-related dracut options if
ip= is set explicitly") ensures kdump network-related dracut options
are set according to admin's intention. It relies on KDUMP_COMMANDLINE
& KDUMP_COMMANDLNE_APPEND config options for that. But these options
are currently not applicable for fadump case. Instead, rely on the
parameters passed to the running kernel, as capture kernel boot is
likely to use the same parameters as production kernel for fadump.

Fixes: bbe9b1281cd6 ("Do not add  network-related dracut options if ip= is set explicitly")
Signed-off-by: Hari Bathini <hbathini@linux.ibm.com>