### PR TITLE
mkdumprd: replace mkinitrd with native dracut

### DIFF
--- a/doc/implementation/Implementation_Guide.txt
+++ b/doc/implementation/Implementation_Guide.txt
@@ -160,7 +160,7 @@ While NFS and CIFS can be handled via mounting, FTP and SFTP must be handled in
 the copy process (via external binary or a library). We need both network access
 and disk access in the initrd. For this, we need the disk drivers and network
 drivers and network configuration. This is only a configuration problem since
-everything is already implemented in +mkinitrd+ to provide network boot (NFS
+everything is already implemented in +dracut+ to provide network boot (NFS
 root) facility.
 
 Filtering

--- a/doc/man/mkdumprd.8.txt.in
+++ b/doc/man/mkdumprd.8.txt.in
@@ -54,7 +54,7 @@ because
 * the kdump initrd should use no splash screen,
 * the kdump initrd includes *kdumptool*(8) and all required libraries.
 
-This script calls *mkinitrd*(8) with all required parameters. If the initrd
+This script calls *dracut*(8) with all required parameters. If the initrd
 already exists, it checks first if the configuration file or the kernel are
 newer, and only rebuilds the initrd if necessary.
 
@@ -102,7 +102,7 @@ later.
 
 SEE ALSO
 --------
-*kdumptool*(8), *mkinitrd*(8),
+*kdumptool*(8), *dracut*(8),
 http://en.opensuse.org/Kdump[_http://en.opensuse.org/Kdump_]
 
 

--- a/init/mkdumprd
+++ b/init/mkdumprd
@@ -24,6 +24,7 @@ FORCE=0
 QUIET=0
 DEBUG=false
 DRACUT=/usr/bin/dracut
+UPDATE_BOOTLOADER=/sbin/update-bootloader
 
 #
 # Prints usage.                                                              {{{
@@ -76,12 +77,13 @@ function build_fadumprd()
 {
     # With fadump, this script has no control over which kernel will
     # be booted after a crash, but any installed kernel can be used
-    # to save the dump. Consequently, let mkinitrd regenerate initrd
+    # to save the dump. Consequently, let dracut regenerate initrd
     # for all installed kernels.
 
-    $DEBUG && export dracut_args="--debug"
+    DRACUT_ARGS="--force --regenerate-all"
+    $DEBUG && DRACUT_ARGS="--debug $DRACUT_ARGS"
     echo "Regenerating all initrds ..." >&2
-    eval "bash -$- /sbin/mkinitrd"
+    eval "bash -$- $DRACUT $DRACUT_ARGS && type -P $UPDATE_BOOTLOADER &> /dev/null && $UPDATE_BOOTLOADER --refresh"
 }                                                                          # }}}
 
 #


### PR DESCRIPTION
Currently `mkinitrd` is just a wrapper that internally calls `dracut` and `update-bootloader`.
Since it will be removed in a near future release, it should be replaced. See jsc#PED-265 and bsc#1202443.

PS: maybe adding the `--parallel` option could be considered if messy logs are not a problem (https://github.com/dracutdevs/dracut/commit/6d923262)