### PR TITLE
Remove build dependency for wicked

### DIFF
--- a/packaging/suse/kdump.spec
+++ b/packaging/suse/kdump.spec
@@ -69,7 +69,6 @@ BuildRequires:  libxslt
 BuildRequires:  pkgconfig
 BuildRequires:  systemd-sysvinit
 BuildRequires:  util-linux-systemd
-BuildRequires:  wicked
 BuildRequires:  zlib-devel
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(udev)
@@ -87,7 +86,6 @@ BuildRequires:  qemu-ipxe
 BuildRequires:  qemu-vgabios
 BuildRequires:  systemd-sysvinit
 BuildRequires:  util-linux-systemd
-BuildRequires:  wicked
 %endif
 Requires:       /usr/bin/sed
 Requires:       curl


### PR DESCRIPTION
NetworkManager is the default now everywhere going forward (Tumbleweed, MicroOS, ALP) and on ALP, wicked will not even exist.