### PR TITLE
Fix shell condition

### DIFF
--- a/dracut/setup-kdump.functions
+++ b/dracut/setup-kdump.functions
@@ -843,7 +843,7 @@ function kdump_update_mount()						   # {{{
     if [ "$device" = "/dev/root" ]; then
         root=$(kdump_get_root_from_commandline)
 
-        if [ -n $root ]; then
+        if [ -n "$root" ]; then
             device=$root
         fi
     fi


### PR DESCRIPTION
`-n` followed by a variable without quotes always evaluates to true.

E.g.:

```
# echo "root=$root"
root=
# if [ -n $root ]; then echo "root=$root"; fi
root=
# if [ -n "$root" ]; then echo "root=$root"; fi
# root=/dev/vda1
# if [ -n "$root" ]; then echo "root=$root"; fi
root=/dev/vda1
```