### PR TITLE
Run kdump.service only after kdump-early.service is done (boo#1196335)

### DIFF
--- a/init/kdump.service
+++ b/init/kdump.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Load kdump kernel and initrd
-After=local-fs.target network.service YaST2-Second-Stage.service YaST2-Firstboot.service
+After=local-fs.target network.service YaST2-Second-Stage.service YaST2-Firstboot.service kdump-early.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
kdump needs to run after kdump-early, not before and not simultaneously. In the latter case, one of the kexec_load calls would fail with EBUSY.