### PR TITLE
powerpc: update fadump sysfs node path

### DIFF
--- a/70-kdump.rules.in
+++ b/70-kdump.rules.in
@@ -22,7 +22,7 @@ GOTO="kdump_end"
 LABEL="kdump_try_restart"
 PROGRAM="/bin/cat /sys/kernel/kexec_crash_loaded", RESULT!="0", RUN+="/usr/lib/kdump/load-once.sh"
 @if @ARCH@ ppc64 ppc64le
-SUBSYSTEM=="memory", TEST=="/sys/kernel/fadump_registered", PROGRAM="/bin/cat /sys/kernel/fadump_registered", RESULT!="0", RUN+="/usr/lib/kdump/load-once.sh"
+SUBSYSTEM=="memory", TEST=="/sys/kernel/fadump/registered", PROGRAM="/bin/cat /sys/kernel/fadump/registered", RESULT!="0", RUN+="/usr/lib/kdump/load-once.sh"
 @endif
 
 LABEL="kdump_end"

--- a/init/load.sh
+++ b/init/load.sh
@@ -4,8 +4,8 @@
 #  Load the kdump kernel 
 
 KEXEC=/sbin/kexec
-FADUMP_ENABLED=/sys/kernel/fadump_enabled
-FADUMP_REGISTERED=/sys/kernel/fadump_registered
+FADUMP_ENABLED=/sys/kernel/fadump/enabled
+FADUMP_REGISTERED=/sys/kernel/fadump/registered
 UDEV_RULES_DIR=/run/udev/rules.d
 kdump_initrd=/var/lib/kdump/initrd
 kdump_kernel=/var/lib/kdump/kernel

--- a/init/unload.sh
+++ b/init/unload.sh
@@ -4,7 +4,7 @@
 #  Unload the kdump kernel
 
 KEXEC=/sbin/kexec
-FADUMP_REGISTERED=/sys/kernel/fadump_registered
+FADUMP_REGISTERED=/sys/kernel/fadump/registered
 UDEV_RULES_DIR=/run/udev/rules.d
 
 . /usr/lib/kdump/kdump-read-config.sh


### PR DESCRIPTION
The fadump sysfs nodes /sys/kernel/fadump_[enabled|registered], have been relocated to /sys/kernel/fadump/[enabled|registered] by kernel commits d418b19f34ed ("powerpc/fadump: Reorganize /sys/kernel/fadump_* sysfs files").

To ensure compatibility, symbolic links were added for each relocated sysfs entry. Nonetheless, note that these symbolic links might be removed later, as they have been deprecated by kernel commit 3f5f1f22ef10 ("Documentation/ABI: Mark /sys/kernel/fadump_* sysfs files deprecated")

This patch updates the scripts to use the updated fadump sysfs files.