### PR TITLE
/Kdump/mnt mount issue for fadump case

### DIFF
--- a/dracut/kdump-save
+++ b/dracut/kdump-save
@@ -39,7 +39,11 @@ function main() {
 	case "${KDUMP_PROTO}" in
 		file)
 			# modified by dracut module to dereference symlinks
-			FILE_PATH="/kdump/mnt${KDUMP_SAVEDIR}"
+			MOUNT_POINT="/kdump/mnt"
+			FILE_PATH="${MOUNT_POINT}${KDUMP_SAVEDIR}"
+			if [[ "$KDUMP_FADUMP" == "true" ]] && [[ ! -w "$MOUNT_POINT" ]];  then
+				mount -o remount,rw  $MOUNT_POINT
+			fi
 			;;
 		ftp)
 			# split URL into host and directory parts, lftp fails when

--- a/init/mkdumprd
+++ b/init/mkdumprd
@@ -66,8 +66,11 @@ function get_mount()
 			    esac
 			done
 
-			TARGET="${MOUNTPOINT}${TARGET}"
-			KDUMP_DRACUT_MOUNT_OPTION="${SOURCE} ${TARGET} ${FS} ${OPTIONS}"
+			DUMP_TARGET="${MOUNTPOINT}${TARGET}"
+			KDUMP_DRACUT_MOUNT_OPTION="${SOURCE} ${DUMP_TARGET} ${FS} ${OPTIONS}"
+			if [[ "$KDUMP_FADUMP" == "true" ]] && [[ "$TARGET" == "/" ]]; then
+				KDUMP_DRACUT_MOUNT_OPTION="${KDUMP_DRACUT_MOUNT_OPTION},x-systemd.requires=/sysroot"
+			fi
 			;;
 		cifs)
                         # split URL into host, directory, user and password parts


### PR DESCRIPTION
There are two patches in this pull request.

1. fadump/mkdumprd: add /sysroot dependency to kdump mount point
    When the fadump kernel boots, it is observed that for certain
    filesystems like ext4, /sysroot fails to mount because /kdump/mnt is
    mounted first, leading to a failure in dump collection. Fix this by
    adding /sysroot dependency to kdump mount point for fadump case.

2. fadump/kdump-save: remount /kdump/mnt as Read-Write
    It is observed that despite having an rw option for the /kdump/mnt fstab
    entry, the file system is mounted as read-only. So, update the kdump-save
    script to remount the /kdump/mnt if it is mounted as read-only for the fadump case.