### PR TITLE
fadump/udev: Avoid fadump re-registration if kernel is hotplug ready

### DIFF
--- a/70-kdump.rules.in
+++ b/70-kdump.rules.in
@@ -22,6 +22,7 @@ GOTO="kdump_end"
 LABEL="kdump_try_restart"
 PROGRAM="/bin/cat /sys/kernel/kexec_crash_loaded", RESULT!="0", RUN+="/usr/lib/kdump/load-once.sh"
 @if @ARCH@ ppc64 ppc64le
+TEST=="/sys/kernel/fadump/hotplug_ready", PROGRAM="/bin/cat /sys/kernel/fadump/hotplug_ready", RESULT=="1", GOTO="kdump_end"
 SUBSYSTEM=="memory", TEST=="/sys/kernel/fadump/registered", PROGRAM="/bin/cat /sys/kernel/fadump/registered", RESULT!="0", RUN+="/usr/lib/kdump/load-once.sh"
 @endif
 


### PR DESCRIPTION
Currently, fadump is re-registered on memory add/remove events. However, with the introduction of the kernel commit c6c5b14dac0d ("powerpc: make fadump resilient with memory add/remove events"), elfcorehdr creation is moved to the second kernel. This makes fadump re-registration on memory add/remove events unnecessary.

To indicate to userspace that the kernel is hotplug ready for the fadump case, a new sysfs entry, /sys/kernel/fadump/hotplug_ready, is introduced. If the hotplug_ready sysfs is set to 1, then there is no need to re-register fadump.

No impact for kernels without /sys/kernel/fadump/hotplug_ready sysfs node.

Relevant kernel commit links:
1. https://msgid.link/20240422195932.1583833-2-sourabhjain@linux.ibm.com
2. https://msgid.link/20240422195932.1583833-3-sourabhjain@linux.ibm.com