### PR TITLE
[RFC] sysconfig/kdump: change KDUMP_CPU default value to 0

### DIFF
--- a/sysconfig.kdump.in
+++ b/sysconfig.kdump.in
@@ -13,17 +13,15 @@
 KDUMP_KERNELVER=""
 
 ## Type:	integer
-## Default:	1
+## Default:	0
 ## ServiceRestart:	kdump
 #
-# Number of CPUs to be used in the kdump environment. You may want to
-# increase the number if computing power is the bottleneck in your setup.
-#
-# If the value is zero, use all available CPUs.
+# Number of CPUs to be used in the kdump environment. The default value is 0,
+# which means all available CPUs will be used to collect the dump."
 #
 # See also: kdump(5).
 #
-KDUMP_CPUS=1
+KDUMP_CPUS=0
 
 ## Type:	string
 ## Default:	""


### PR DESCRIPTION
By default, use all available CPUs to collect the dump instead of just one CPU. This reduces the dump collection time significantly, specially for the systems with very large memory configuration.

The graph below show the time reduction in dump collection on large memory system from 4 Hours to 10 Minutes.

                               |
                       14000   | *
                               |
                               |
                               |
                               |
                               |
                               |
                        1600   |      *
                               |
                               |
                        1400   |
 execution Time (Sec)          |
                               |
                        1200   |
                               |
                               |
                        1000   |
                               |            *
                               |
                        800    |
                               |
                               |                   *
                        600    |
                               |                          *     *
                               |
                                ------------------------------------
                                   1    9    17    25     33    41

                                          Number of Threads

System details:
Architecture: PowerPC
/proc/vmcore size: 3.7T
Filter level: 1

Similar tests with different filter levels, 31 and 16, also show significant reduction in time consumption for dump collection.

Although the above tests were performed only on the PowerPC architecture, but I think using all CPUs for dump collection will have performance benefits on other architectures too.