### PR TITLE
fadump: pass additional parameters for capture kernel

### DIFF
--- a/doc/man/kdump.5.txt.in
+++ b/doc/man/kdump.5.txt.in
@@ -168,6 +168,24 @@ This option can be useful for debugging.
 
 Default is "false".
 
+FADUMP_COMMANDLINE_APPEND
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This variable describes all additional command line parameters that are passed
+to fadump capture kernel other than the default parameters (/proc/cmdline).
+These additional parameters are typically those that optimize resources, reduce
+memory footprint and disable complex and/or troublesome components that have
+no significance for dump capture environment.
+
+For network based dumping, you may have to add a _net_delay_ parameter to
+specify the extra delay in seconds that is needed for the network device
+to become fully operational, e.g. _net_delay=20_ will wait 20 seconds before
+continuing after the network device is configured. This parameter is used by
+the network setup code in the resulting initrd.
+
+Default is "nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0
+ hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2".
+
 endif::[]
 
 KEXEC_OPTIONS

--- a/init/load.sh
+++ b/init/load.sh
@@ -6,6 +6,7 @@
 KEXEC=/sbin/kexec
 FADUMP_ENABLED=/sys/kernel/fadump/enabled
 FADUMP_REGISTERED=/sys/kernel/fadump/registered
+FADUMP_BOOTARGS_APPEND=/sys/kernel/fadump/bootargs_append
 UDEV_RULES_DIR=/run/udev/rules.d
 kdump_initrd=/var/lib/kdump/initrd
 kdump_kernel=/var/lib/kdump/kernel
@@ -202,6 +203,21 @@ function fadump_bootloader()
 }
 
 #
+# Pass additional parameters to FADump capture kernel.
+function fadump_append_params()
+{
+    if [ -f $FADUMP_BOOTARGS_APPEND ]; then
+	output=$( { echo $FADUMP_COMMANDLINE_APPEND > "$FADUMP_BOOTARGS_APPEND" ; } 2>&1)
+	if [ $? -eq 0 ]; then
+            output=$(cat "$FADUMP_BOOTARGS_APPEND")
+            msg="Additional parameters for fadump kernel: '$output'"
+        else
+            msg="WARNING: Failed to setup additional parameters for fadump capture kernel: $output"
+        fi
+    fi
+}
+
+#
 # Update fadump configuration
 function load_kdump_fadump()
 {
@@ -215,6 +231,9 @@ function load_kdump_fadump()
     local msg
     local result=0
     local output
+
+    # Pass additional parameters to FADump capture kernel.
+    fadump_append_params
 
     # Re-registering of FADump is supported in kernel (see bsc#1108170).
     # So, don't bother about whether FADump was registered already

--- a/kdump-read-config.sh
+++ b/kdump-read-config.sh
@@ -15,6 +15,7 @@ function kdump_read_config_main()
 	option int 	 KDUMP_DUMPLEVEL 31
 	option bool 	 KDUMP_FADUMP false
 	option bool 	 KDUMP_FADUMP_SHELL false
+	option string 	 FADUMP_COMMANDLINE_APPEND "nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0 hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2"
 	option int 	 KDUMP_FREE_DISK_SIZE 64
 	option string 	 KDUMP_HOST_KEY ""
 	option bool 	 KDUMP_IMMEDIATE_REBOOT true

--- a/sysconfig.kdump.in
+++ b/sysconfig.kdump.in
@@ -86,6 +86,20 @@ KDUMP_FADUMP="false"
 #
 KDUMP_FADUMP_SHELL="false"
 
+## Type:        string
+## Default:     "nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0 hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2"
+## ServiceRestart:     kdump
+#
+# Set this variable if you want to _append_ values to the default
+# command line string during dump capture.
+#
+# For network based dumps, you may have to add a "net_delay" parameter
+# here. Consult the man page for details.
+#
+# See also: kdump(5).
+#
+FADUMP_COMMANDLINE_APPEND="nr_cpus=16 numa=off cgroup_disable=memory cma=0 kvm_cma_resv_ratio=0 hugetlb_cma=0 transparent_hugepage=never novmcoredd udev.children-max=2"
+
 @endif
 ## Type:	string
 ## Default:	""


### PR DESCRIPTION
Since kernel commit 3416c9daa6b13 ("powerpc/fadump: pass additional parameters when fadump is active"), fadump supports passing additional parameters to dump capture kernel. Leverage that support here to pass additional parameters to dump capture kernel. The default bootargs to append for dump capture kernel boot are picked to optimize resources and reduce memory footprint in dump capture environment.