### PR TITLE
dracut: kdump_bond_config does not properly filter ro keys

### DIFF
--- a/dracut/setup-kdump.functions
+++ b/dracut/setup-kdump.functions
@@ -364,13 +364,14 @@ function kdump_bond_config()						   # {{{
 
 	local ro_keys=(
 	    ad_actor_key
+	    ad_actor_system
 	    ad_aggregator
 	    ad_num_ports
 	    ad_partner_key
 	    ad_partner_mac
 	)
 	local ro_sed="s/,\(${ro_keys[@]}\)=[^,]*//g"
-	ro_sed="${ro_sed// /\|}"
+	ro_sed="${ro_sed// /\\|}"
 
 	opts=$(ip -d link show "$bond" | \
 	    sed -n '3{s/^ *bond//;s/ \([^ ]*\) \([^ ]*\)/,\1=\2/g;'"$ro_sed"';p}')


### PR DESCRIPTION
In order for the read-only keys to be properly filtered out, the pipe separator needs to be properly escaped

Additionally, while ad_actor_system is not strictly-speaking a read-only key, it's value is a MAC address, which will break parsing if not filtered out, so add it to the ro_keys.

References: bsc#1233137