### PR TITLE
Fadump: Use FADUMP_COMMANDLINE_APPEND to detect explicit IP configuration

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -62,7 +62,7 @@ kdump_ip_set_explicitly() {
 	local opts
 
 	if [ "$KDUMP_FADUMP" = true ]; then
-		_opts="`cat /proc/cmdline`"
+		_opts="$FADUMP_COMMANDLINE_APPEND"
 	else
 		_opts="$KDUMP_COMMANDLINE $KDUMP_COMMANDLINE_APPEND"
 	fi


### PR DESCRIPTION
Commit bbe9b1281cd6 ("Do not add network-related dracut options if ip= is set explicitly") skipped automatic network configuration if the ip= kernel argument was present in KDUMP_COMMANDLINE or KDUMP_COMMANDLINE_APPEND.

Since those options were not available for fadump, commit 61a7cb57b1cd ("Fix network-related dracut options handling for fadump case") used the current kernel parameters instead. So, if the production kernel has an ip= kernel argument, automatic network configuration is skipped for fadump.

However, if the network interface required for accessing the NFS dump target (as configured in KDUMP_SAVEDIR) is not reachable via the ip= configuration, the fadump kernel fails to mount the NFS dump target, and dump collection fails.

Fix this by using FADUMP_COMMANDLINE_APPEND to detect explicit ip= configuration instead of relying on the current kernel arguments. With this change, both the ip= and KDUMP_SAVEDIR network interfaces will be configured in the fadump kernel - just like it is done for kdump.