### PR TITLE
Remove BuildRequire for dhcp-client

### DIFF
--- a/packaging/suse/kdump.spec
+++ b/packaging/suse/kdump.spec
@@ -78,7 +78,6 @@ BuildRequires:  pkgconfig(udev)
 # so turn them on unconditionally
 # %if %{with calibrate}
 BuildRequires:  %qemu
-BuildRequires:  dhcp-client
 BuildRequires:  dracut >= 047
 BuildRequires:  iputils
 BuildRequires:  kernel-default


### PR DESCRIPTION
The ISC dhcp client is EOL.
I am not sure why exactly it even is a BuildRequire as the package seems to build just fine without it.