### PR TITLE
Add caution for KDUMP_CPUS configuration

### DIFF
--- a/doc/man/kdump.5.txt.in
+++ b/doc/man/kdump.5.txt.in
@@ -111,6 +111,13 @@ is set to the number of CPUs.
 
 Decreasing the number of CPUs will lower the memory required by kdump.
 
+Caution:
+Increasing KDUMP_CPUS to a very high number can significantly raise memory
+requirements in the kdump kernel. This may cause memory pressure, which in
+extreme cases can lead to kdump kernel boot failure and ultimately result
+in dump capture failure. Carefully evaluate the memory availability and
+crashkernel reservation before increasing this value.
+
 Default is 32.
 
 

--- a/sysconfig.kdump.in
+++ b/sysconfig.kdump.in
@@ -56,6 +56,13 @@ KDUMP_KERNELVER=""
 #
 # If the value is zero, use all available CPUs.
 #
+# Caution:
+# Increasing KDUMP_CPUS to a very high number can significantly raise memory
+# requirements in the kdump kernel. This may cause memory pressure, which in
+# extreme cases can lead to kdump kernel boot failure and ultimately result
+# in dump capture failure. Carefully evaluate the memory availability and
+# crashkernel reservation before increasing this value.
+#
 # See also: kdump(5).
 #
 KDUMP_CPUS=32


### PR DESCRIPTION
Setting KDUMP_CPUS to a very high value - for example, 900 or more can cause the kdump/fadump kernel to fail during boot due to limited system resources in the dump capture environment.

Add a caution note in the configuration file and the man page to warn users about the potential consequences of setting KDUMP_CPUS to such a high value.