### PR TITLE
Exclude specific panic sysctls from capture kernel initrd

### DIFF
--- a/dracut/setup-kdump.functions
+++ b/dracut/setup-kdump.functions
@@ -719,6 +719,9 @@ function kdump_filter_sysctl()						   # {{{
 	"$root"/etc/sysctl.conf
     do
 	sed -i -e '/^[ \t]*vm\./d' "$f"
+	sed -i -e '/^[ \t]*kernel\.panic_on_warn/d' "$f"
+	sed -i -e '/^[ \t]*kernel\.softlockup_panic/d' "$f"
+	sed -i -e '/^[ \t]*kernel\.panic_on_rcu_stall/d' "$f"
     done
 
     eval "$restoreopt"


### PR DESCRIPTION
The following sysctl configurations are retained in the capture kernel initrd, which can cause dump capture failures unnecessarily:

- kernel.panic_on_warn
- kernel.softlockup_panic
- kernel.panic_on_rcu_stall

For example, if kernel.panic_on_warn is set in the capture kernel and a warning is triggered, the capture kernel will panic, causing the dump capture to fail.

The same applies to the other two sysctl configurations. The capture kernel should avoid panicking on soft-lockups and RCU stalls, as the system might still recover.

Fix this by excluding the above-mentioned sysctl configurations from being retained in the capture kernel initrd.

Reported-by: Misbah Anjum N <misanjum@linux.ibm.com>